### PR TITLE
Add the config for the Raspberry Pi 3 B+ board

### DIFF
--- a/sbc_library.scad
+++ b/sbc_library.scad
@@ -50,7 +50,7 @@
                            momentary_6x6x4, fixed color for usb2 micro otg, adjust all header heights, 
                            added mipi_csi, mipi_dsi, m.2_stud
     20220515 Version 1.0.7 added pcie(), jst_ph(), cm(), cm_holder(), corrected odroid-m1 heatsink height and sbc location, and other fixes and adjustments
-    
+    20220623 Version 1.0.7 added pwr5.5_9.5x7
     see https://github.com/hominoids/SBC_Case_Builder
 
     place(x,y,size_x,size_y,rotation,side,type,pcbsize_z)
@@ -61,7 +61,7 @@
     memory(x,y,rotation,side,type,pcbsize_z) - "emmc","emmc_plug","sodimm_5.2","sodimm_9.2"
     switch(x,y,rotation,side,type,pcbsize_z) - "slide_4x9"
     button(x,y,rotation,side,type,pcbsize_z) - "momentary_6x6x9","momentary_6x6x4","momentary_6x6x4_90","momentary_4x2x1"
-    plug(x,y,rotation,side,type,pcbsize_z) - "pwr2.5_5x7.5","pwr5.5_7.5x11.5","pwr5.5_10x10","rtc_micro","audio_micro","uart_micro","molex_4x1","small_encl_satapwr"
+    plug(x,y,rotation,side,type,pcbsize_z) - "pwr2.5_5x7.5","pwr5.5_7.5x11.5","pwr5.5_10x10","pwr5.5_9.5x7","rtc_micro","audio_micro","uart_micro","molex_4x1","small_encl_satapwr"
     usb2(x,y,rotation,side,type,pcbsize_z) - "single_vert_a","double_stacked_a","micro"
     usb3(x,y,rotation,side,type,pcbsize_z) - "double_stacked_a"
     network(x,y,rotation,side,type,pcbsize_z) - "rj45_single"
@@ -362,6 +362,21 @@ module plug(x,y,rotation,side,type,pcbsize_z) {
             }
             color("white") translate([5,10,5]) rotate([90,0,0]) 
             cylinder(d=1.5, h=9,$fn=30);
+        }
+    }
+    // 5.5mm power plug 9.5mm x 7mm
+    if(type=="pwr5.5_9.5x7") {
+        size_x = 9.5;
+        size_y = 9.5;        
+        place(x,y,size_x,size_y,rotation,side,type,pcbsize_z)
+        union() {
+            difference () {
+                color("silver") translate([0,0,0]) cube([size_x, size_y, 7]);
+                color("black") translate([5.7,8.49,3.5]) rotate([90,0,0]) 
+                cylinder(d=3.35, h=8.5, $fn=30);
+            }
+            color("white") translate([5.7,8.5,3.5]) rotate([90,0,0]) 
+            cylinder(d=1.4, h=8.5,$fn=30);
         }
     }
 

--- a/sbc_library.scad
+++ b/sbc_library.scad
@@ -71,7 +71,7 @@
     ic(x,y,rotation,side,type,pcbsize_z) - "ic_2.8x2.8","ic_3x3","ic_3.7x3.7","ic_4x4","ic_4.7x4.7","ic_5x5","ic_5.75x5.75","ic_6x6","ic_6.4x6.4",ic_6.75x6.75",
                                            "ic_7x7","ic_4.3x5.1","ic_5.4x5.3","ic_6.7x8.4","ic_9x9","ic_11x8","ic_13x8","ic_13x9","ic_16x10"
     audio(x,y,rotation,side,type,pcbsize_z) - "out-in-spdif","jack_3.5"
-    storage(x,y,rotation,side,type,pcbsize_z) - "sdcard","sdcard_i","sata_header","sata_power_vrec","sata_encl_power","sata_encl_header","m.2_header","m.2_stud"
+    storage(x,y,rotation,side,type,pcbsize_z) - "sdcard","sdcard_i","microsdcard","sata_header","sata_power_vrec","sata_encl_power","sata_encl_header","m.2_header","m.2_stud"
     combo(x,y,rotation,side,type,pcbsize_z) - "rj45-usb2_double","rj45-usb3_double"
     jumper(x,y,rotation,side,type,pcbsize_z) - "header_2x1","header_3x2","header_5x1","header_6x1","header_7x1"
     misc(x,y,rotation,side,type,pcbsize_z) - "ir_1","led_3x1.5","lcd_2.2","bat_hold_1"
@@ -1044,6 +1044,24 @@ module storage(x,y,rotation,side,type,pcbsize_z) {
                 color("black") translate([.5,-.5,2]) cube([10.5, 5.5, 1]);
             }
         }
+    }
+
+    // micro sd card
+    if (type == "microsdcard") {
+        size_x = 13.2;
+        size_y = 14.1;
+        place(x, y, size_x, size_y, rotation, side, type, pcbsize_z)
+        union() {
+            for(loc_x = [3.4:1.2:12]) {
+                color("silver") translate([loc_x, 0, 0]) cube([0.7, 13.5, 0.4]);
+            }
+            difference() {
+                color("silver") translate([0, 0, 0]) cube([size_x, size_y, 1.4]);
+                translate([2.6, 10.31, -1]) cube([9.6, 3.8, 5]);
+                translate([0.2, 0.5, 0.2]) cube([12.8, 13.7, 1]);
+            }
+        }
+
     }
     
     // sata single header type

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -592,17 +592,30 @@ sbc_data = [
             19,9,0,"top","misc","lcd_2.2"],                         // lcd location, rotation, side, class and type
 
             // RasberryPi 3B+, 3B, 3A+, 2, 1B+
-            ["rpi3b+",85.6,56.5,1,3,16,6,                           // sbc model, pcb size and component height
-            3.5,3.5,2.75,3.5,52.5,2.75,                             // pcb holes 1 and 2 location and pcb hole size
-            61.5,3.5,2.75,61.5,52.5,2.75,                           // pcb holes 3 and 4 location and pcb hole size
+            ["rpi3b+",85,56,1,3,16,6,                               // sbc model, pcb size and component height
+            3.5,3.5,3,3.5,52.5,3,                                   // pcb holes 1 and 2 location and pcb hole size
+            61.5,3.5,3,61.5,52.5,3,                                 // pcb holes 3 and 4 location and pcb hole size
             0,0,0,0,0,0,                                            // pcb holes 5 and 6 location and pcb hole size
             0,0,0,0,0,0,                                            // pcb holes 7 and 8 location and pcb hole size
             0,0,0,0,0,0,                                            // pcb holes 9 and 10 location and pcb hole size             
-            14,14,1.5,19.975,24.525,0,0,"top",                      // soc1 size, location, rotation and side
+            13,13,1.25,23,23,0,0,"top",                             // soc1 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc2 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc3 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc4 size, location, rotation and side
-            0,0,0,"","",""],                                        // component location, rotation, side, class and type
+            1,21.7,90,"bottom","storage","microsdcard",             // sdcard location, rotation, side, class and type
+            6.8,-1,0,"top","usb2","micro",                          // usb2 otg location, rotation, side, class and type
+            24.5,-1,0,"top","video","hdmi_a",                       // hdmi location, rotation, side, class and type
+            65,2.25,270,"top","network","rj45_single",              // ethernet location, rotation, side, class and type
+            69.61,39.6,270,"top","usb2","double_stacked_a",         // usb2 location, rotation, side, class and type
+            69.61,21.6,270,"top","usb2","double_stacked_a",         // usb1 location, rotation, side, class and type
+            7,50,0,"top","gpio","header_40",                        // gpio location, rotation, side, class and type
+            53,30,0,"top","ic","ic_7x7",                            // usbhub 5mm location, rotation, side, class and type
+            1.1,17.5,90,"top","video", "mipi_csi",                  // display location, rotation, side, class and type
+            43.5,1,270,"top","video", "mipi_csi",                   // camera location, rotation, side, class and type
+            50.25,0,0,"top","audio", "jack_3.5",                    // audio port location, rotation, side, class and type
+            1.1, 43.2, 90, "top", "misc", "led_3x1.5",              // activity led location, rotation, side, class and type
+            1.1, 47, 90, "top", "misc", "led_3x1.5"                 // power led location, rotation, side, class and type
+            ],
             
             // Pine64 SBCs
             ["a64",127,79,1.6,3.5,0,0,                              // sbc model, pcb size and component height
@@ -643,8 +656,8 @@ sbc_data = [
             -2.4, 32.02, 90, "top", "network", "rj45_single",         // rj45 ethernet port
             -2.4, 53.15, 90, "top", "video", "hdmi_a",              // hdmi port
             114.4, 10.16, 270, "top", "audio", "jack_3.5",           // audio jack
-            118, 19.3, 270, "top", "button", "momentary_6x6x4_90", // Power button
-            118, 28.85, 270, "top", "button", "momentary_6x6x4_90", // Reset button
+            118, 19.5, 270, "top", "button", "momentary_6x6x4_90", // Power button
+            118, 29, 270, "top", "button", "momentary_6x6x4_90", // Reset button
             112, 38.49, 270, "top", "usb2", "double_stacked_a",     // USB-2 stack
             112, 55.85, 270, "top", "usb3", "double_stacked_a",       // USB-3 / USB-C stack
             13.6, 73.4, 0, "top", "button", "momentary_4x2x1",     // recover button

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -62,7 +62,7 @@
     video - "hdmi_a","dp-hdmi_a","mipi_csi","mipi_dsi"
     fan - "micro","encl_pmw","encl_pmw_h"
     gpio - "encl_header_30","encl_header_12","header_40","header_20"
-    ic - "ic_2.8x2.8","ic_3x3","ic_3.7x3.7","ic_4x4","ic_4.7x4.7","ic_5x5","ic_5.75x5.75","ic_6x6","ic_6.4x6.4",ic_6.75x6.75",
+    ic - "ic_2.8x2.8","ic_3x3","ic_3.7x3.7","ic_4x4","ic_4.7x4.7","ic_5x5","ic_5.75x5.75","ic_6x6","ic_6.4x6.4","ic_6.75x6.75",
          "ic_7x7","ic_4.3x5.1","ic_5.4x5.3","ic_6.7x8.4","ic_9x9","ic_11x8","ic_13x8","ic_13x9","ic_16x10"
     audio - "out-in-spdif","jack_3.5"
     storage - "sdcard","sdcard_i","sata_header","sata_power_vrec","sata_encl_power","sata_encl_header","m.2_header","m.2_stud"
@@ -639,23 +639,23 @@ sbc_data = [
             0,0,0,0,0,0,0,"",                                       // soc2 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc3 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc4 size, location, rotation and side
-            -1.5,12,90,"top","plug","pwr5.5_7.5x11.5",              // component, location, rotation, side, class and type
-            -1.5, 32, 90, "top", "network", "rj45_single",          // rj45 ethernet port
-            -1.5, 52.4, 90, "top", "video", "hdmi_a",               // hdmi port
-            114.4, 9.8, 270, "top", "audio", "jack_3.5",            // audio jack
-            118, 19.5, 270, "top", "button", "momentary_6x6x4_90",  // Power button
-            118, 28.5, 270, "top", "button", "momentary_6x6x4_90",  // Reset button
-            112, 38.7, 270, "top", "usb2", "double_stacked_a",      // USB-2 stack
-            112, 55, 270, "top", "usb3", "double_stacked_a",        // USB-3 / USB-C stack
-            13.6, 73.4, 0, "top", "button", "momentary_4x2x1",      // recover button
-            42.6, 73.4, 0, "top", "gpio", "header_40",              // gpio
-            43.5, 0, 0, "top", "pcie", "x4",                        // pcie x4 port
-            98.9, 14.7, 0, "top", "memory", "emmc_plug",            // mmc port
-            97.2, 0, 0, "bottom", "storage", "sdcard",              // micro sdcard
-            94.6, 73.4, 0, "top", "jst_ph", 2,                      // fan header
-            101.4, 73.4, 0, "top", "jst_ph", 3,                     // SPDIF header
-            110.3, 73.4, 0, "top", "jst_ph", 2,                     // rtc header
-            10.6, 13.2, 270, "top", "jst_ph", 4],                   // sata dc out
+            -2.4,11.92,90,"top","plug","pwr5.5_9.5x7",                                        // component, location, rotation, side, class and type
+            -2.4, 32.02, 90, "top", "network", "rj45_single",         // rj45 ethernet port
+            -2.4, 53.15, 90, "top", "video", "hdmi_a",              // hdmi port
+            114.4, 10.16, 270, "top", "audio", "jack_3.5",           // audio jack
+            118, 19.3, 270, "top", "button", "momentary_6x6x4_90", // Power button
+            118, 28.85, 270, "top", "button", "momentary_6x6x4_90", // Reset button
+            112, 38.49, 270, "top", "usb2", "double_stacked_a",     // USB-2 stack
+            112, 55.85, 270, "top", "usb3", "double_stacked_a",       // USB-3 / USB-C stack
+            13.6, 73.4, 0, "top", "button", "momentary_4x2x1",     // recover button
+            42.6, 73.4, 0, "top", "gpio", "header_40",             // gpio
+            43.5, 0, 0, "top", "pcie", "x4",                       // pcie x4 port
+            98.9, 14.7, 0, "top", "memory", "emmc_plug",           // mmc port
+            97.2, 0, 0, "bottom", "storage", "sdcard",             // micro sdcard
+            94.6, 73.4, 0, "top", "jst_ph", 2,                     // fan header
+            101.4, 73.4, 0, "top", "jst_ph", 3,                    // SPDIF header
+            110.3, 73.4, 0, "top", "jst_ph", 2,                    // rtc header
+            10.6, 13.2, 270, "top", "jst_ph", 4],                  // sata dc out
 
             ["atomicpi",130.44,99.9,1.63,3,14,8,                    // sbc model, pcb size and component height
             4.22,3.95,3,126.22,3.95,3,                              // pcb holes 1 and 2 location and pcb hole size

--- a/sbc_test.scad
+++ b/sbc_test.scad
@@ -47,3 +47,6 @@ linear_extrude(height = 2) {translate([400,100,0]) text("Jetson Nano");}
 
 translate ([390,260,0]) sbc("show2");
 linear_extrude(height = 2) {translate([410,240,0]) text("Show2");}
+
+translate([530, 0, 0]) sbc("rpi3b+");
+linear_extrude(height = 2) { translate([530, -20, 0]) text("RPi 3 B+"); }

--- a/sbc_test_components.scad
+++ b/sbc_test_components.scad
@@ -177,6 +177,8 @@ storage(295,115,0,"top","sata_encl_power",0);
 linear_extrude(height = 1) {translate([295,110,0]) text("sata_encl_power",size=5, halign="left");}
 storage(295,138,0,"top","sata_power_vrec",0);
 linear_extrude(height = 1) {translate([295,130,0]) text("sata_power_vrec",size=5, halign="left");}
+storage(295, 153, 0, "top", "microsdcard", 0);
+linear_extrude(height = 1) {translate([295,145,0]) text("microsdcard",size=5, halign="left");}
 
 // combo class
 linear_extrude(height = 2) {translate([360,-5,0]) rotate([0,0,90]) text("combo", size=8, halign="right");}


### PR DESCRIPTION
Added everything for the RPi 3 B+ board. Should also add a note that the same board layout is used for the RPi 1 B+ board.