### PR TITLE
fix for rock5b v1.3

### DIFF
--- a/sbc_library.scad
+++ b/sbc_library.scad
@@ -337,6 +337,15 @@ module button(x,y,rotation,side,type,pcbsize_z) {
             color("black") translate([1.5,-1.4,.5]) cube([4, 1.5, 1.5]);
         }
     }
+    if(type=="momentary_4.5x3.5x2.5_90") {
+        size_x = 4.5;
+        size_y = 3.5;
+        place(x,y-3.5,size_x,size_y,rotation,side,type,pcbsize_z)
+        rotate([90, 0, 0]) union() {
+            color("silver") translate([0,0,0]) cube([size_x,size_y,2.5]);
+            color("black") translate([2.25,1.75,2.5]) cylinder(r=1,h=1,$fn=30);
+        }
+    }
 
 
 }

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -1203,22 +1203,22 @@ sbc_data = [
             ["rockpi5b-v1.3",100.20,74.25,1.6,3.5,18,11,            // sbc model, pcb size and component height
             3.5,21.6875,3.5,3.5,70.6875,3.5,                        // pcb holes 1 and 2 location and pcb hole size
             96.7188,21.6375,3.5,96.6688,70.6875,3.5,                // pcb holes 3 and 4 location and pcb hole size
-            61.5688,70.6375,3.5,61.3217,34.9374,3,                  // pcb holes 5 and 6 location and pcb hole size
-            9.8687,21.8875,3,9.8529,54.8875,3,                      // pcb holes 7 and 8 location and pcb hole size
-            63.8687,21.8875,3,63.8687,54.8875,3,                    // pcb holes 9 and 10 location and pcb hole size             
-            23,23,1.6,21.3437,24.4874,0,0,"top",                    // soc1 size, location, rotation and side
+            61.5688,70.6375,3.5,0,0,0,                              // pcb holes 5 and 6 location and pcb hole size
+            9.45,53.25,3,60.95,33.25,3,                             // pcb holes 7 and 8 location and pcb hole size
+            0,0,0,0,0,0,                                            // pcb holes 9 and 10 location and pcb hole size
+            23,23,1.6,28,39.7,0,0,"top",                            // soc1 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc2 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc3 size, location, rotation and side
             0,0,0,0,0,0,0,"",                                       // soc4 size, location, rotation and side
-            79,64,180,"bottom","storage","microsdcard2",            // sdcard location, rotation, side, class and type
-            10,55,0,"top","heatsink","40mm_active",                 // heatsink location, rotation, side, class and type
-            42,15.5,270,"bottom","memory","emmc",                   // emmc location, rotation, side, class and type             
-            84,41.5,270,"bottom","storage","m.2_header",            // m2 socket location, rotation, side, class and type
-            0,53,0,"bottom","storage","m.2_stud",                   // m2 stud location, rotation, side, class and type
-            71,59.5,0,"top","storage","m.2_header",                 // m2 socket location, rotation, side, class and type
-            81,32,0,"top","storage","m.2_stud",                     // m2 stud location, rotation, side, class and type
-            1,60.75,270,"top","jst_ph",2,                           // fan header
-            95,58,90,"top","jst_ph",2,                              // fan header
+            93.45,40,270,"top","storage","microsdcard2",            // sdcard location, rotation, side, class and type
+            9.45,53.55,0,"top","heatsink","40mm_active",            // heatsink location, rotation, side, class and type
+            10.5,54.5,90,"bottom","memory","emmc",                  // emmc location, rotation, side, class and type
+            91.635,30.55,270,"bottom","storage","m.2_header",       // m2 socket location, rotation, side, class and type
+            15.1,41.45,0,"bottom","storage","m.2_stud",             // m2 stud location, rotation, side, class and type
+            74.25,58.65,0,"top","storage","m.2_header",             // m2 socket location, rotation, side, class and type
+            85.17,33.4,0,"top","storage","m.2_stud",                // m2 stud location, rotation, side, class and type
+            0.15,36.7,270,"top","jst_ph",2,                         // fan header
+            97,25.45,90,"top","plug","audio_micro",                 // fan header
             21.93,-2,0,"top","video","hdmi_a_vertical",             // hdmi location, rotation, side, class and type
             34.63,-2,0,"top","video","hdmi_a_vertical",             // hdmi location, rotation, side, class and type
             13.3137,-1,0,"top","usbc","single_vertical",            // usbc location, rotation, side, class and type
@@ -1228,8 +1228,8 @@ sbc_data = [
             65.09,-2,0,"top","usb3","double_stacked_a",             // usb1 location, rotation, side, class and type
             7.3173,68.2974,0,"top","gpio","header_40",              // gpio location, rotation, side, class and type
             3.22,0,0,"top","audio","jack_3.5",                      // audio jack
-            80.2188,70.75,180,"top","button","momentary_4x2x1",     // Power button
-            87.1191,70.75,180,"top","button","momentary_4x2x1"],    // Reset button
+            82.25,71,180,"top","button","momentary_4.5x3.5x2.5_90", // Power button
+            89.2,71,180,"top","button","momentary_4.5x3.5x2.5_90"], // Reset button
 
             
             // from mech drawings - unverified


### PR DESCRIPTION
Fix the location of modules on rock5b v1.3.
Create a new button `momentary_4.5x3.5x2.5_90`.
Use `audio_micro` as fan header because this need an opening on the case.