### PR TITLE
Add opir1 (Orange Pi R1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ tinkerboard-r2(r2s) - YELLOW, unverified mostlikely usable and/or missing minor 
 
 
 
-### OrangePi: 4
+### OrangePi: 5
 
 opi5 - YELLOW, unverified mostlikely usable and/or missing minor information.
 
@@ -202,6 +202,8 @@ opizero(opizeroplus) - YELLOW, unverified mostlikely usable and/or missing minor
 opizero2 - YELLOW, unverified mostlikely usable and/or missing minor information.
 
 opir1plus_lts - YELLOW, unverified mostlikely usable and/or missing minor information.
+
+opir1 - YELLOW, unverified mostlikely usable and/or missing minor information.
 
 
 

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -1870,6 +1870,33 @@ sbc_data = [
             3.9,33.43,0,"top","ic","ic_15x15"],                     // memory
 
             // MANUFACTURER: OrangePi
+            // NAME: OrangePi R1
+            // SOURCE: OEM Mechanical drawings & hand measured PCB
+            // TODO: NONE
+            // STATUS: YELLOW, unverified
+            ["opir1",46,55,1.6,2,13.5,2.1,                          // sbc model, pcb size and component height
+            3,10,3,3,52,3,                                          // pcb holes 1 and 2
+            43,10,3,43,52,3,                                        // pcb holes 3 and 4
+            0,0,0,0,0,0,                                            // pcb holes 5 and 6
+            0,0,0,0,0,0,                                            // pcb holes 7 and 8
+            0,0,0,0,0,0,                                            // pcb holes 9 and 10
+            14,14,1.25,23.1,33.9,0,0,"top",                         // soc1 size, location, rotation and side
+            0,0,0,0,0,0,0,"",                                       // soc2 size, location, rotation and side
+            0,0,0,0,0,0,0,"",                                       // soc3 size, location, rotation and side
+            0,0,0,0,0,0,0,"",                                       // soc4 size, location, rotation and side
+            11.5,39,180,"bottom","storage","microsdcard",           // sdcard
+            6.3,-4.7,0,"top","network","rj45_reverse_single",       // ethernet
+            24,-4.7,0,"top","network","rj45_reverse_single",        // ethernet
+            32.3,48.5,180,"top","usb2","micro",                     // usb2
+            6.4,18,180,"top","jumper","header_3x1",                 // serial
+            0,14.5,90,"top","gpio","header_26",                     // expansion port
+            43.2,14.5,90,"top","jumper","header_13x1",              // audio, usb, tvout
+            11,35.9,90,"top","ic","ic_13x9",                        // memory
+            18.5,20,0,"top","ic","ic_4x4",                          // ethernet phy
+            29,18,0,"top","ic","ic_5x5",                            // wifi
+            24,32,0,"bottom","ic","ic_5x5"],                        // spi flash
+
+            // MANUFACTURER: OrangePi
             // NAME: OrangePi 5
             // SOURCE: Hand measured 3d model
             // TODO: None

--- a/sbc_models.scad
+++ b/sbc_models.scad
@@ -47,7 +47,7 @@
                      "rock4b+","rock4c","rock4c+","rock5b-v1.3","rock5b-v1.42",
                      "vim1","vim2","vim3l","vim3","vim4",
                      "tinkerboard","tinkerboard-s","tinkerboard-2","tinkerboard-r2",
-                     "opi5","opizero","opizero2","opir1plus_lts",
+                     "opi5","opizero","opizero2","opir1plus_lts","opir1",
                      "licheerv+dock",
                      "visionfive2"
 */

--- a/sbc_test.scad
+++ b/sbc_test.scad
@@ -200,9 +200,13 @@ translate([1005,185,0]) sbc("opizero2");
 linear_extrude(height = 2) { translate([1005,165,0]) text("OPi Zero2"); }
 color("yellow",.3) translate([1005,165,-1]) cube([63,10,1]);
 
-translate([1005,285,0]) sbc("opir1plus_lts");
-linear_extrude(height = 2) { translate([1005,265,0]) text("OPi R1 Plus LTS"); }
-color("yellow",.3) translate([1005,265,-1]) cube([102,10,1]);
+translate([1005,275,0]) sbc("opir1plus_lts");
+linear_extrude(height = 2) { translate([1005,255,0]) text("OPi R1 Plus LTS"); }
+color("yellow",.3) translate([1005,255,-1]) cube([102,10,1]);
+
+translate([1005,375,0]) sbc("opir1");
+linear_extrude(height = 2) { translate([1005,350,0]) text("OPi R1"); }
+color("yellow",.3) translate([1005,350,-1]) cube([45,10,1]);
 
 translate ([1120,0,0]) sbc("jetsonnano");
 linear_extrude(height = 2) {translate([1130,-20,0]) text("Jetson Nano");}


### PR DESCRIPTION
Introduce [Orange Pi R1](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-R1.html).

Rudimentary tested with the following case:
```json
"opir1_shell": {
    "$fn": "90",
    "accessory_highlight": "false",
    "accessory_name": "none",
    "adjust": "0.01",
    "bottom_ext_standoff": "[6.25, 0, 2.5, 8, 4, 1, 0, 0, 0, 4.5, 5.1]",
    "bottom_front_left": "0",
    "bottom_front_right": "0",
    "bottom_rear_left": "0",
    "bottom_rear_right": "0",
    "bottom_standoff": "[5.5, 2, 3.5, 8, 3, 1, 1, 0, 0, 4.5, 5.1]",
    "c_fillet": "3.5",
    "case_design": "shell",
    "case_ext_standoffs": "false",
    "case_ffn": "90",
    "case_fn": "360",
    "case_offset_bz": "4",
    "case_offset_tz": "7",
    "case_offset_x": "0",
    "case_offset_y": "1",
    "case_style": "none",
    "cooling": "none",
    "exhaust_vents": "none",
    "fillet": "0",
    "floorthick": "1.5",
    "gap": "1.5",
    "gpio_opening": "none",
    "indents": "true",
    "individual_part": "bottom",
    "lip": "5",
    "lower_bottom": "0",
    "move_front": "0",
    "move_leftside": "0",
    "move_rear": "0",
    "move_rightside": "0",
    "pcb_loc_x": "0",
    "pcb_loc_y": "1.5",
    "pcb_loc_z": "0",
    "raise_top": "0",
    "sata_punchout": "false",
    "sbc_bottom_standoffs": "true",
    "sbc_highlight": "false",
    "sbc_model": "opir1",
    "sbc_off": "false",
    "sbc_top_standoffs": "true",
    "sidethick": "1.5",
    "sidewall_support": "false",
    "tol": "0.25",
    "top_ext_standoff": "[6.25, 0, 2.25, 8, 4, 4, 0, 1, 0, 4.5, 5.1]",
    "top_front_left": "0",
    "top_front_right": "0",
    "top_rear_left": "0",
    "top_rear_right": "0",
    "top_standoff": "[5.5, 0, 3.5, 8, 4, 4, 1, 1, 1, 3.5, 5.1]",
    "view": "platter",
    "vu_rotation": "[15, 0, 0]",
    "wallthick": "1.5"
}
```
