### PR TITLE
Add opi5max (Orange Pi 5 Max)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ USAGE: sbc(model, enableheatsink = "default", fansize = 0, enablegpio =  "defaul
                  "rock4a","rock4a+","rock4b","rock4b+","rock4c","rock4c+","rock5b-v1.3","rock5b","rock5b+","nio12l"
                  "vim1","vim2","vim3l","vim3","vim4",
                  "tinkerboard","tinkerboard-s","tinkerboard-2","tinkerboard-2s","tinkerboard-r2","tinkerboard-r2s",
-                 "opi5","opizero","opizero2","opir1plus_lts","opir1",
+                 "opi5","opizero","opizero2","opir1plus_lts","opir1", "opi5max",
                  "lepotato","sweetpotato","tirtium-h2+","tritium-h3","tritium-h5","solitude","alta"
                  "jetsonnano",
                  "bpif3",

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -92,7 +92,7 @@
              "rock4a","rock4a+","rock4b","rock4b+","rock4c","rock4c+","rock5b-v1.3","rock5b","rock5b+","nio12"
              "vim1","vim2","vim3l","vim3","vim4",
              "tinkerboard","tinkerboard-s","tinkerboard-2","tinkerboard-2s","tinkerboard-r2","tinkerboard-r2s",
-             "opi5","opizero","opizero2","opir1plus_lts","opir1",
+             "opi5","opizero","opizero2","opir1plus_lts","opir1","opi5max",
              "lepotato","sweetpotato","tirtium-h2+","tritium-h3","tritium-h5","solitude","alta"
              "jetsonnano",
              "licheerv+dock",
@@ -4494,7 +4494,7 @@ sbc_data = [
             "heatsink","stub",0,6,38,1.75,"top",[0,0,0],[0,0,0],[40],[true,40,0,"fan_hex"]],
 
 
-            // Xunlong Software: OPiZero, OpiZero2, OPiR1, OPiR1 Plus LTS, Opi5
+            // Xunlong Software: OPiZero, OpiZero2, OPiR1, OPiR1 Plus LTS, Opi5, Opi5Max
 
             ["opizero",[
                     "NAME: OrangePi Zero",
@@ -4754,6 +4754,66 @@ sbc_data = [
             "gpio","open",0,10,56.5,0,"top",[0,0,0],[13,2,6],["thruhole","black","male",2.54,"#fee5a6"],[true,15,-2,"vent"],
             "heatsink","stub",0,16,44,1.25,"top",[0,0,0],[0,0,0],[40],[true,40,0,"fan_hex"]],
 
+            ["opi5max",[
+                    "NAME: OrangePi 5 Max",
+            "MANUFACTURER: Xunlong Software",
+                     "SOC: Rockchip RK3588",
+                    "ARCH: ARMv8.2-A",
+               "PROCESSOR: Cortex-A76 Quad-Core 2.4Ghz Cortex-A55 Quad-Core 1.8Ghz",
+                  "MEMORY: 4/8/16GiB LPDDR4",
+                     "GPU: Mali-G610 MP4",
+                     "VPU: decode 8KP60 H.265/VP9, 8KP30 H.264, 4KP60 AV1, encoder 8KP30 H.264/H.265",
+                     "NPU: RKNN 6 TOPS",
+                     "MCU: NA",
+                 "NETWORK: 2.5Gbps RJ45",
+                "WIRELESS: WiFi6E, Bluetooth 5.3",
+                   "VIDEO: HDMI-A 2.1x2",
+                 "DISPLAY: MIPI-DSI",
+                  "CAMERA: MIPI-CSIx2, MIPI D-PHY",
+                   "AUDIO: Jack 3.5, I2S, HDMI",
+                 "STORAGE: MicroSD, eMMC",
+                    "PCIe: NVME M.2 M Key",
+                     "USB: USB2x2, USB3x2",
+                    "GPIO: 40pin",
+                     "OTG: USBC",
+                      "IR: NA",
+                    "UART: Yes",
+                 "SENSORS: NA",
+                   "POWER: 5V/4A USBC",
+                  "SOURCE: OEM mechanical drawings and hand measured PCB",
+                    "TODO: none",
+                  "STATUS: green, verified"
+            ],
+            "pcb","rectangle",0,0,0,0,"top",[0,0,0],[89,57,1.6],[1,"#008066",0,0,0,16,4,0],[false,10,2,"default"],
+            "pcbhole","round",0,7.5,3.5,0,"top",[0,0,0],[3,0,0],["both","#fee5a6","rear",6,"left_rear"],[false,10,2,"default"],
+            "pcbhole","round",0,7.5,52.5,0,"top",[0,0,0],[3,0,0],["both","#fee5a6","front",6,"left_front"],[false,10,2,"default"],
+            "pcbhole","round",0,65.5,3.5,0,"top",[0,0,0],[3,0,0],["both","#fee5a6","rear",6,"right_rear"],[false,10,2,"default"],
+            "pcbhole","round",0,65.5,52.5,0,"top",[0,0,0],[3,0,0],["both","#fee5a6","front",6,"right_front"],[false,10,2,"default"],
+            "pcbsoc","flat",0,30,19,0,"top",[0,0,0],[23,23,1.74],[1],[false,10,2,"default"],
+            "network","rj45_single",0,70.5,2.5,0,"top",[0,0,270],[0,0,0],[0],[true,10,2,"default"],
+            "usb3","double_stacked_a",0,74,23,0,"top",[0,0,270],[0,0,0],[0],[true,10,2,"default"],
+            "usb2","double_stacked_a",0,74,41,0,"top",[0,0,270],[0,0,0],[0],[true,10,2,"default"],
+            "usbc","single_vertical",0,58,-2.4,0,"top",[0,0,0],[0,0,0],[0],[true,10,2,"default"],
+            "audio","mic_round",0,2.25,2.75,0,"top",[0,0,0],[4.5,4.5,2],[0],[true,10,2,"default"],
+            "audio","jack_3.5",0,29,-3,0,"top",[0,0,0],[6.0,14,5],[6,0],[true,10,2,"default"],
+            "video","hdmi_a",0,11.0,-2.7,0,"top",[0,0,0],[0,0,0],[0],[true,10,2,"default"],
+            "video","hdmi_a",0,39,-2.7,0,"top",[0,0,0],[0,0,0],[0],[true,10,2,"default"],
+            "header","open",0,0.5,51.5,0,"top",[0,0,90],[2,1,6],["thruhole","black","male",2.54,"#fee5a6"],[true,10,2,"default"],
+            "button","momentary_6x6x4_90",0,1.5,5.5,0,"top",[0,0,90],[0,0,0],[0],[true,10,2,"default"],
+            "button","momentary_4x2x1",0,5,39.5,0,"top",[0,0,0],[0,0,0],[0],[true,10,2,"default"],
+            "ic","generic",0,10.5,29.8,0,"top",[0,0,0],[14,12.2,.8],["dimgrey"],[true,10,2,"default"],
+            "ic","generic",0,61.5,36.5,0,"top",[0,0,0],[12,12,1.8],["dimgrey"],[true,10,2,"default"],
+            "ic","generic",0,62,8.6,0,"top",[0,0,0],[6,6,.8],["dimgrey"],[true,10,2,"default"],
+            "fpc","fh12",0,2.5,18.5,0,"top",[0,0,270],[30,0,0],["smt","side","white","black"],[true,10,2,"default"],
+            "b2b","df40",0,52,14,0,"top",[0,0,180],[30,0,1.5],["default","black","female"],[true,10,2,"default"],
+            "b2b","df40",0,69,19.5,0,"top",[0,0,90],[30,0,1.5],["default","black","female"],[true,10,2,"default"],
+            "b2b","df40",0,57,33.5,0,"top",[0,0,270],[30,0,1.5],["default","black","female"],[true,10,2,"default"],
+            "b2b","df40",0,42,2,0,"bottom",[0,0,0],[30,0,1.5],["default","black","female"],[true,10,2,"default"],
+            "antenna","ipex",0,69.5,52.5,0,"top",[0,0,0],[2.3,2.85,1.25],[0],[false,10,2,"default"],
+            "gpio","open",0,11.5,50,0,"top",[0,0,0],[20,2,6],["smt","black","male",2.54,"#fee5a6"],[true,15,-2,"vent"],
+            "storage","microsdcard",0,0,37,0,"bottom",[0,0,270],[0,0,0],[0],[true,10,2,"default"],
+            "storage","m.2_header",0,2,13.5,0,"bottom",[0,0,90],[0,0,0],[0],[true,10,2,"default"],
+            "heatsink","stub",0,16,40.5,1.74,"top",[0,0,0],[0,0,0],[40],[true,40,0,"fan_1"]],
 
             // Nvidia: Jetson Nano
 

--- a/sbc_models.scad
+++ b/sbc_models.scad
@@ -33,7 +33,7 @@
                              "rock4a","rock4a+","rock4b","rock4b+","rock4c","rock4c+","rock5b-v1.3","rock5b","rock5b+","nio12l",
                              "vim1","vim2","vim3l","vim3","vim4",
                              "tinkerboard","tinkerboard-s","tinkerboard-2","tinkerboard-2s","tinkerboard-r2","tinkerboard-r2s",
-                             "opi5","opizero","opizero2","opir1plus_lts","opir1",
+                             "opi5","opizero","opizero2","opir1plus_lts","opir1","opi5max",
                              "lepotato","sweetpotato","tirtium-h2+","tritium-h3","tritium-h5","solitude","alta"
                              "jetsonnano",
                              "licheerv+dock",

--- a/sbc_models_viewer.scad
+++ b/sbc_models_viewer.scad
@@ -27,7 +27,7 @@ use <sbc_models_library.scad>
 /* [SBC and MCU] */
 view = "3D Model"; // [3D Model, 2D Sections, 3D Reference Manual, All Devices]
 section_position = 2; //[-2:.5:4]
-sbc_model = "c1+"; // ["c1+", "c2", "c4", "hc4", "xu4", "xu4q", "mc1", "hc1", "n1", "n2", "n2+", "n2l", "n2lq", "m1", "m1s", "m2", "h2", "h2+", "h3", "h3+", "h4", "h4+", "h4_ultra", "show2", "rpipico", "rpipicow", "rpicm4+ioboard", "rpicm1", "rpicm3", "rpicm3l", "rpicm3+", "rpicm4s", "rpicm4", "rpicm4l", "rpizero", "rpizerow", "rpizero2w", "rpi1a+", "rpi1b+", "rpi2b", "rpi3a+", "rpi3b", "rpi3b+", "rpi4b", "rpi5", "a64", "a64lts", "rock64", "rockpro64", "quartz64a", "quartz64b", "h64b", "star64", "soedge_rk1808","soedge_a-baseboard", "rock4a", "rock4b", "rock4a+", "rock4b+", "rock4c", "rock4c+", "rock5b-v1.3", "rock5b", "rock5bq", "rock5b+", "nio12l", "vim1", "vim2", "vim3", "vim3l", "vim4", "tinkerboard", "tinkerboard-s", "tinkerboard-2", "tinkerboard-2s", "tinkerboard-r2", "tinkerboard-r2s", "opizero", "opizero2", "opir1plus_lts", "opir1", "opi5", "jetsonnano", "lepotato", "sweetpotato", "tritium-h2+", "tritium-h3", "tritium-h5", "solitude", "alta", "atomicpi", "visionfive2", "visionfive2q", "bpif3", "licheerv+dock", "milk-v_duos","rak19007", "cnano-avr128da48", "nodemcu-32s", "cs-solarmeter", "feather-m0_express", "feather-m0_wifi", "feather-m4_express", "ssi-eeb", "ssi-ceb", "atx", "micro-atx", "dtx", "flex-atx", "mini-dtx", "mini-itx", "mini-itx_thin", "mini-stx", "mini-stx_thin", "nano-itx", "nuc", "pico-itx"]
+sbc_model = "c1+"; // ["c1+", "c2", "c4", "hc4", "xu4", "xu4q", "mc1", "hc1", "n1", "n2", "n2+", "n2l", "n2lq", "m1", "m1s", "m2", "h2", "h2+", "h3", "h3+", "h4", "h4+", "h4_ultra", "show2", "rpipico", "rpipicow", "rpicm4+ioboard", "rpicm1", "rpicm3", "rpicm3l", "rpicm3+", "rpicm4s", "rpicm4", "rpicm4l", "rpizero", "rpizerow", "rpizero2w", "rpi1a+", "rpi1b+", "rpi2b", "rpi3a+", "rpi3b", "rpi3b+", "rpi4b", "rpi5", "a64", "a64lts", "rock64", "rockpro64", "quartz64a", "quartz64b", "h64b", "star64", "soedge_rk1808","soedge_a-baseboard", "rock4a", "rock4b", "rock4a+", "rock4b+", "rock4c", "rock4c+", "rock5b-v1.3", "rock5b", "rock5bq", "rock5b+", "nio12l", "vim1", "vim2", "vim3", "vim3l", "vim4", "tinkerboard", "tinkerboard-s", "tinkerboard-2", "tinkerboard-2s", "tinkerboard-r2", "tinkerboard-r2s", "opizero", "opizero2", "opir1plus_lts", "opir1", "opi5", "opi5max", "jetsonnano", "lepotato", "sweetpotato", "tritium-h2+", "tritium-h3", "tritium-h5", "solitude", "alta", "atomicpi", "visionfive2", "visionfive2q", "bpif3", "licheerv+dock", "milk-v_duos","rak19007", "cnano-avr128da48", "nodemcu-32s", "cs-solarmeter", "feather-m0_express", "feather-m0_wifi", "feather-m4_express", "ssi-eeb", "ssi-ceb", "atx", "micro-atx", "dtx", "flex-atx", "mini-dtx", "mini-itx", "mini-itx_thin", "mini-stx", "mini-stx_thin", "nano-itx", "nuc", "pico-itx"]
 
 sbc_off = false;
 sbc_mask = false;
@@ -1817,6 +1817,10 @@ if(view == "All Devices") {
     translate([565,375,0]) sbc("opir1");
     linear_extrude(height = 2) { translate([565,350,0]) text("OPi R1"); }
     color("green",.3) translate([565,350,-1]) cube([45,10,1]);
+
+    translate([565,460,0]) sbc("opi5max");
+    linear_extrude(height = 2) { translate([565,440,0]) text("OrangePi 5 Max"); }
+    color("green",.3) translate([565,440,-1]) cube([95,10,1]);
 
     translate ([680,0,0]) sbc("alta");
     linear_extrude(height = 2) {translate([680,-20,0]) text("Alta");}


### PR DESCRIPTION
I'm currently working on integrating support for the Orange Pi 5 Max, which is part of the Orange Pi 5 family of single-board computers.

Product information is available here:
http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/service-and-support/Orange-Pi-5-Max.html

My initial verification involved printing a "fitted" case using [SBC_Case_Builder](https://github.com/hominoids/SBC_Case_Builder). I found that the "pcb loc z" setting required a +2mm adjustment for a perfect fit without accessories. I suspect that the height of the M2.Header is a little short, leading to generated internal standoffs that is too short.

This is a test print to confirm a perfect IO shield fit. I will print a complete "fitted" case later today.
![opi5max_io_shield](https://github.com/user-attachments/assets/11c67c23-4aee-467d-a240-5e0b409a24b0)
