### PR TITLE
Further parameterize screw terminal blocks and add barrier block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The next step is to populate the SBC model's configuration entry with it's compo
  *  storage  - "microsdcard", "microsdcard2", "microsdcard3", "microsdcard3_i", "sata_header",
                "sata_power_vrec", "sata_encl_power", "m.2_header", "m.2_stud"
  *  switch   - "slide_4x9", "slide_7x3.5x1"
- *  terminal - "gtb"(parametric)
+ *  terminal - "screw", "barrier"(parametric)
  *  uart     - ""molex_5267", "molex_5268" 
  *  usb2     - "micro", "single_horizontal_a", "single_vertical_a", "double_stacked_a", "single_b"
  *  usb3     - "single_horizontal_a", "single_vertical_a", "double_stacked_a", "double_stacked_usb3-usbc","double_stacked_usb3-usb2"
@@ -995,20 +995,22 @@ DESCRIPTION: creates switches
 ```
  CLASS NAME: terminal
 DESCRIPTION: creates terminal blocks
-      USAGE: terminal, type, pcb_id, loc_x, loc_y, loc_z, side, rotation, size, data, mask
+      USAGE: terminal, type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z, mask
 
-                       type = "gtb"
-                     pcb_id = parent PCB
+                       type = "screw", "barrier"
                       loc_x = x location placement
                       loc_y = y location placement
                       loc_z = z location placement
                        side = "top", "bottom"
                  rotation[] = object rotation
-                    size[0] = #positions
-                    size[1] = body depth
-                    size[2] = height
+                    size[0] = #row
+                    size[1] = size_y
+                    size[2] = size_z
                     data[0] = pitch
                     data[1] = body color
+                    data[2] = offset z
+                  pcbsize_z = pcb thickness
+                 enablemask = true produces mask, false produces model
                     mask[0] = true enables component mask
                     mask[1] = mask length
                     mask[2] = mask setback

--- a/lib/terminal.scad
+++ b/lib/terminal.scad
@@ -22,7 +22,7 @@
 
           USAGE: terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z, enablemask, mask)
 
-                          type = "gtb"
+                          type = "screw", "barrier"
                          loc_x = x location placement
                          loc_y = y location placement
                          loc_z = z location placement

--- a/lib/terminal.scad
+++ b/lib/terminal.scad
@@ -28,9 +28,9 @@
                          loc_z = z location placement
                           side = "top", "bottom"
                     rotation[] = object rotation
-                       size[0] = #positions
-                       size[1] = body depth
-                       size[2] = height
+                       size[0] = #row
+                       size[1] = size_y
+                       size[2] = size_z
                        data[0] = pitch
                        data[1] = body color
                      pcbsize_z = pcb thickness
@@ -49,20 +49,19 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
     mlen = mask[1];
     back = mask[2];
     mstyle = mask[3];
+    pcolor = "#fee5a6";
 
-    // type green terminal block
-    if(type=="gtb") {
+    // type screw terminal block
+    if(type=="screw") {
 
         pitch = data[0];
         hcolor = data[1];
-        rows = size[0];
-        size_x = pitch * rows;
+        row = size[0];
+        size_x = pitch * row;
         size_y = size[1];
-        height = size[2];
-        pcolor = "#fee5a6";
-
-        adj = .01;
+        size_z = size[2];
         $fn = 90;
+        screw_d = pitch-1;
         size_xm = size_x+2;
         size_ym = size_y+.5;
 
@@ -71,8 +70,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([0, back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r, 4.15, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r, size_y/2, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -80,8 +79,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y-2, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([0, back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r, 4.15, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r, size_y/2, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -89,8 +88,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([2,1+back,3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r+2, 4.5, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r+2, size_y/2+.5, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -98,8 +97,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([0,.5+back,3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r, 4.5, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r, size_y/2+.5, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -107,8 +106,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([2, back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r+2, 4.15, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r+2, size_y/2, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -116,8 +115,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([2, .5+back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r+2, 4.5, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r+2, size_y/2+.5, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -125,8 +124,8 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([0, 1+back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r, 4.5, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r, size_y/2+.5, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
@@ -134,40 +133,40 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
                 union() {
                     translate([0, back, 3]) rotate([90, 0, 0]) slot(5, size_x, mlen);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        translate([r, 4.15, height-back]) cylinder(d=3.7, h=mlen);
+                    for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                        translate([r, size_y/2, size_z-back]) cylinder(d=screw_d, h=mlen);
                     }
                 }
             }
         }
         if(enablemask == false) {
 
-            place(loc_x, loc_y, loc_z, size_x, size_y, rotation, side, pcbsize_z)        
+            place(loc_x, loc_y, loc_z, size_x, size_y, rotation, side, pcbsize_z)
             union() {
                 difference() {
                     union() {
-                        color(hcolor) cube([size_x, size_y, height/2]);
-                        color(hcolor) translate([0, 0, (height/2)-.01]) cube([size_x, size_y, height/2]);
+                        color(hcolor) cube([size_x, size_y, size_z/2]);
+                        color(hcolor) translate([0, 0, (size_z/2)-.01]) cube([size_x, size_y, size_z/2]);
                     }
-                    color(hcolor) translate([-1, -3, 6.99]) rotate([-15, 0, 0]) cube([(pitch*rows)+2, 3, 10]);
-                    color(hcolor) translate([-1, 8, 10]) rotate([15, 0, 0]) cube([(pitch*rows)+2, 3, 10]);
-                    for(r=[pitch/2:pitch:size_x]) {
-                        color(hcolor) translate([r, 4.15, height-3]) cylinder(d=3.7, h=4);
+                    color(hcolor) translate([-1, -3, 6.99]) rotate([-15, 0, 0]) cube([size_x+2, 3, 10]);
+                    color(hcolor) translate([-1, size_y, 6.99]) rotate([15, 0, 0]) cube([size_x+2, 3, 10]);
+                    for(r=[.75/2+pitch/2:pitch-(.75/row):size_x]) {
+                        color(hcolor) translate([r, size_y/2, size_z-3]) cylinder(d=screw_d, h=4);
                     }
-                    for(r=[.75:pitch:size_x]) {
-                        color(hcolor) translate([r, -1, 1]) cube([3.5,5,4]);
+                    for(r=[.75:pitch-(.75/row):size_x]) {
+                        color(hcolor) translate([r, -1, 1]) cube([pitch-.75,5,4]);
                     }
                 }
-                for(r=[pitch/2:pitch:size_x]) {
-                    color(pcolor) translate([r, 4.15, -3.2]) cube([.64, .64, 3.3]);
+                for(r=[pitch/2+0.75/2:pitch-(.75/row):size_x]) {
+                    color(pcolor) translate([r-.32, size_y/2, -3.2]) cube([.64, .64, 3.3]);
                     difference() {
-                        color("silver") translate([r, 4.15, height-2.5]) cylinder(d=3.7, h=2);
-                        color("silver") translate([r-.5, 4.15-(4.15/2), height-1.25]) cube([1,4,1]);
+                        color("silver") translate([r, size_y/2, size_z-2.5]) cylinder(d=screw_d, h=2);
+                        color("silver") translate([r-.5, size_y/2-screw_d/2, size_z-1.25]) cube([1,4,1]);
                     }
                 }
-                for(r=[1:pitch:size_x]) {
-                    color("silver") translate([r, .5, 1]) cube([3, 4, .25]);
-                    color("silver") translate([r, .5, 4.5]) cube([3, 4, .5]);
+                for(r=[.75:pitch-(.75/row):size_x-0.75]) {
+                    color("silver") translate([r, .5, 1]) cube([pitch-.75, 4, .25]);
+                    color("silver") translate([r, .5, 4.5]) cube([pitch-.75, 4, .5]);
                 }
             }
         }

--- a/lib/terminal.scad
+++ b/lib/terminal.scad
@@ -33,6 +33,7 @@
                        size[2] = size_z
                        data[0] = pitch
                        data[1] = body color
+                       data[2] = offset z
                      pcbsize_z = pcb thickness
                     enablemask = true produces mask, false produces model
                        mask[0] = true enables component mask
@@ -167,6 +168,93 @@ module terminal(type, loc_x, loc_y, loc_z, side, rotation, size, data, pcbsize_z
                 for(r=[.75:pitch-(.75/row):size_x-0.75]) {
                     color("silver") translate([r, .5, 1]) cube([pitch-.75, 4, .25]);
                     color("silver") translate([r, .5, 4.5]) cube([pitch-.75, 4, .5]);
+                }
+            }
+        }
+    }
+
+    // type barrier terminal block
+    if(type=="barrier") {
+
+        pitch = data[0];
+        hcolor = data[1];
+        z_offset = data[2];
+        row = size[0];
+        size_x = pitch * row;
+        size_y = size[1];
+        size_z = size[2];
+        $fn = 90;
+        pitch_adj = .75;
+        screw_d = pitch-2*pitch_adj;
+        size_xm = size_x+2;
+        size_ym = size_y+.5;
+
+        if(enablemask == true && cmask == true && mstyle == "default") {
+            if(side == "top" && rotation == 0) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([0,back,z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "top" && rotation == 90) {
+                place(loc_x, loc_y-2, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([0,back,z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "top" && rotation == 180) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([2,1+back,z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "top" && rotation == 270) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([0,1+back,z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "bottom" && rotation == 0) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([2, back, z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "bottom" && rotation == 90) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([2, 1+back, z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "bottom" && rotation == 180) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([0, 1+back, z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+            if(side == "bottom" && rotation == 270) {
+                place(loc_x, loc_y, loc_z, size_xm, size_ym, rotation, side, pcbsize_z)
+                union() {
+                    translate([0, back, z_offset]) rotate([90, 0, 0]) cube([size_x, size_z-z_offset, mlen]);
+                }
+            }
+        }
+        if(enablemask == false) {
+            place(loc_x, loc_y, loc_z, size_x, size_y, rotation, side, pcbsize_z)
+            union() {
+                union() {
+                    color(hcolor) cube([size_x, size_y, z_offset]);
+                    color(hcolor) translate([0, size_y-1, z_offset]) cube([size_x, 1, size_z-z_offset]);
+                    for(r=[0:pitch-(pitch_adj/row):size_x]) {
+                        color(hcolor) translate([r, 0, z_offset]) cube([pitch_adj,size_y,size_z-z_offset]);
+                    }
+                }
+                for(r=[pitch/2+pitch_adj/2:pitch-(pitch_adj/row):size_x]) {
+                    color(pcolor) translate([r-.32, screw_d, -3.2]) cube([.64, .64, 3.3]);
+                    difference() {
+                        color("silver") translate([r, screw_d/2, z_offset]) cylinder(d=screw_d, h=2);
+                        color("silver") translate([r-0.5,0,z_offset+1.25]) cube([1,screw_d,1]);
+                    }
                 }
             }
         }

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -76,7 +76,7 @@
  *  storage  - "microsdcard", "microsdcard2", "microsdcard3", "microsdcard3_i", "sata_header",
                "sata_power_vrec", "sata_encl_power", "m.2_header", "m.2_stud"
  *  switch   - "slide_4x9"
- *  terminal - "gtb"(parametric)
+ *  terminal - "screw"(parametric)
  *  uart     - ""molex_5267", "molex_5268" 
  *  usb2     - "micro", "single_horizontal_a", "single_vertical_a", "double_stacked_a"
  *  usb3     - "single_horizontal_a", "single_vertical_a", "double_stacked_a", "double_stacked_usb3-usbc","double_stacked_usb3-usb2"
@@ -5349,12 +5349,12 @@ sbc_data = [
             "power","molex_4x1",0,18,.25,0,"top",[0,0,180],[0,0,0],[0],[false,10,2,"default"],
             "usb2","single_horizontal_a",0,103,-4,0,"top",[0,0,0],[0,14,0],[0],[true,10,2,"default"],
             "usb2","micro",0,122,115,0,"top",[0,0,180],[0,0,0],[0],[true,10,2,"default"],
-            "terminal","gtb",0,50,0,0,"top",[0,0,0],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
-            "terminal","gtb",0,142,40,0,"top",[0,0,270],[2,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
-            "terminal","gtb",0,142,55,0,"top",[0,0,270],[2,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
-            "terminal","gtb",0,63,112,0,"top",[0,0,180],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
-            "terminal","gtb",0,103,112,0,"top",[0,0,180],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
-            "terminal","gtb",0,-.5,3,0,"top",[0,0,90],[11,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,50,0,0,"top",[0,0,0],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,142,40,0,"top",[0,0,270],[2,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,142,55,0,"top",[0,0,270],[2,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,63,112,0,"top",[0,0,180],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,103,112,0,"top",[0,0,180],[3,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
+            "terminal","screw",0,-.5,3,0,"top",[0,0,90],[11,8.3,14],[5,"lightgreen"],[true,10,2,"default"],
             "discrete","led",0,4,77,0,"top",[0,0,90],[5,0,8],["default","green",0,0,0,0,0,0],[true,10,2,"default"],
             "discrete","led",0,4,84,0,"top",[0,0,90],[5,0,8],["default","yellow",0,0,0,0,0,0],[true,10,2,"default"],
             "discrete","led",0,4,97,0,"top",[0,0,90],[5,0,8],["default","red",0,0,0,0,0,0],[true,10,2,"default"],

--- a/sbc_models.cfg
+++ b/sbc_models.cfg
@@ -76,7 +76,7 @@
  *  storage  - "microsdcard", "microsdcard2", "microsdcard3", "microsdcard3_i", "sata_header",
                "sata_power_vrec", "sata_encl_power", "m.2_header", "m.2_stud"
  *  switch   - "slide_4x9"
- *  terminal - "screw"(parametric)
+ *  terminal - "screw", "barrier"(parametric)
  *  uart     - ""molex_5267", "molex_5268" 
  *  usb2     - "micro", "single_horizontal_a", "single_vertical_a", "double_stacked_a"
  *  usb3     - "single_horizontal_a", "single_vertical_a", "double_stacked_a", "double_stacked_usb3-usbc","double_stacked_usb3-usb2"

--- a/sbc_models_viewer.scad
+++ b/sbc_models_viewer.scad
@@ -889,13 +889,13 @@ if(view == "3D Reference Manual") {
         "                  mask[2] = mask setback",
         "                  mask[3] = mstyle default"
         ]];
-    terminal = [["gtb"],[
+    terminal = [["screw", "barrier"],[
         " CLASS NAME: terminal",
         "DESCRIPTION: creates terminal blocks",
         "",
         "      USAGE: terminal, type, pcb_id, loc_x, loc_y, loc_z, side, rotation, size, data, mask",
         "",
-        "                       type = gtb",
+        "                       type = screw, barrier",
         "                     pcb_id = parent PCB",
         "                      loc_x = x location placement",
         "                      loc_y = y location placement",


### PR DESCRIPTION
This pull request:
* refactor the `gtb` style of the `terminal` module, renaming it to "screw" and further parametrizing other aspects
* add support for barrier terminal blocks (style `barrier`)

## Changes to screw terminal blocks:
* Renamed the `gtb` style of the `terminal` module to `screw` for clarity.
* Front wire-hole and top screw-hole sizes are no longer hardcoded.
  * Screw size is estimated as `pitch - 1mm`.
  * Wire hole size is estimated as `pitch - 0.75mm`.
* Top screw hole positions are now centered (`size_y / 2`) instead of hardcoded to support various block sizes.
* [WARNING] This changes the existing terminal blocks model and mask used in the `atomicpi` board.
* Verified with terminal blocks of pitch 3.5mm (KF350-3-5) and 5.0mm (KF128-5-0).
  * KF350-3.5 - https://lcsc.com/datasheet/lcsc_datasheet_2303171000_Cixi-Kefa-Elec-KF350-3-5-2P_C474892.pdf
  * KF128-5.0 - https://lcsc.com/datasheet/lcsc_datasheet_2303171000_Cixi-Kefa-Elec-KF128-5-0-2P_C474950.pdf

![image](https://github.com/user-attachments/assets/7f83f173-2f82-4a67-a0cc-861b4f3a27df)

## Added Barrier Terminal Block Support:
* A new offset z parameter (`data[2]`) allows for adjusting the hole height from the PCB.

![image](https://github.com/user-attachments/assets/94cbcdbd-76b8-4286-9bde-1d0f4e9252fc)
